### PR TITLE
Remove the step that clones the tutorial repository.

### DIFF
--- a/setup/README.md
+++ b/setup/README.md
@@ -4,13 +4,6 @@ Time required: 10 minutes
 
 1. [Download](https://www.docker.com/products/docker-desktop), install, and launch Docker Desktop on your local machine.
 2. [Download](https://git-scm.com/downloads) and install git.
-3. In a terminal window clone the tutorial repository.
-
-   ```
-   $ git clone https://github.com/IBM/max-developer-tutorial.git
-   $ cd max-developer-tutorial
-   ```
-
-4. If you want to complete tutorial module 2 (instead of just reviewing the solution) make sure [Node.js](https://nodejs.org/en/) or [Python](https://www.python.org/) is installed.
+3. If you want to complete tutorial module 2 (instead of just reviewing the solution) make sure [Node.js](https://nodejs.org/en/) or [Python](https://www.python.org/) is installed.
 
 You are ready to [start the tutorial](/modules/module1).


### PR DESCRIPTION
It is not used throughout the tutorial.